### PR TITLE
Fix env name in `prompt_virtualenv`.

### DIFF
--- a/agnosterj.zsh-theme
+++ b/agnosterj.zsh-theme
@@ -359,13 +359,14 @@ prompt_virtualenv() {
     if [[ -n "$CONDA_DEFAULT_ENV" ]]; then
       env="$CONDA_DEFAULT_ENV"
     else
-      env="$VIRTUAL_ENV";
+      env=`basename "$VIRTUAL_ENV"`;
     fi
     if [[ -n "$env" ]]; then
-      prompt_segment blue black "(`basename \"$virtualenv_path\"`)"
+      prompt_segment blue black "($env)"
     fi
   fi
 }
+
 
 epoch_date() {
   unamestr=`uname`

--- a/agnosterj.zsh-theme
+++ b/agnosterj.zsh-theme
@@ -359,14 +359,13 @@ prompt_virtualenv() {
     if [[ -n "$CONDA_DEFAULT_ENV" ]]; then
       env="$CONDA_DEFAULT_ENV"
     else
-      env=`basename "$VIRTUAL_ENV"`;
+      env=`basename "$VIRTUAL_ENV"`
     fi
     if [[ -n "$env" ]]; then
       prompt_segment blue black "($env)"
     fi
   fi
 }
-
 
 epoch_date() {
   unamestr=`uname`


### PR DESCRIPTION
The set and displayed variable names were inconsistent and it was not disable as a result.
In addition, `$CONDA_DEFAULT_ENV` is not a path so we don't need to pass it through `basename`.