### PR TITLE
Wrap `git status` command with GNU `timeout`

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ See the [User Guide](https://github.com/apjanke/agnosterj-zsh-theme/blob/master/
 
 AgnosterJ can be configured by setting various environment variables. For example:
 
-* `$AGNOSTER_PROMPT_SEGMENTS` - List of segments to include in your prompt.
+* `$AGNOSTER_PROMPT_SEGMENTS` - Array of segments to include in your prompt.
 * `$AGNOSTER_PATH_STYLE` – `full`, `short`, or `shrink` – Controls how the current directory is displayed.
 * `$DEFAULT_USER` - A user name you typically log in as, and which should be omitted from the prompt display when you are that user.
 
@@ -87,7 +87,9 @@ By default, the prompt has these segments in this order:
 * `git`
 * `context`
 * `virtualenv`
+* `vaulted`
 * `dir`
+* `kubecontext`
 
 If you want to add, remove, or reorder some segments of the prompt, you can use the array environment variable named `AGNOSTER_PROMPT_SEGMENTS`. There are also `agnoster_add_segment` and `agnoster_remove_segment` functions to help you do this.
 
@@ -102,6 +104,9 @@ Optional segments include:
 * `gcp`
 * `filesystem`
 * `random_emoji`
+* `blank`
+* `hg`
+* `k8s`
 
 ### Examples
 

--- a/doc/UserGuide.md
+++ b/doc/UserGuide.md
@@ -108,6 +108,7 @@ AgnosterJ's behavior can be configured by setting these environment variables.
 * `$AGNOSTER_RANDOM_EMOJI_EACH_PROMPT` – Whether the `prompt_random_emoji` segment should use a different emoji each time a prompt is displayed (1) or keep the same emoji for the duration of a shell session (0).
 * `$AGNOSTER_RANDOM_EMOJI` – The list of emoji characters that `prompt_random_emoji` will draw from.
 * `$AGNOSTER_RANDOM_EMOJI_REALLY_RANDOM` – Set to `1` to get a wider range of random emoji.
+* `$AGNOSTER_PROMPT_TIMEOUT` - Maximum time (seconds) to allow for potentially slow prompt segments. Currently only supported by git.
 
 You can call the `agnoster_setopt` function to see what the current variables affecting AgnosterJ are set to.
 
@@ -119,11 +120,25 @@ TODO: Fill this in.
 
 ### `status`
 
+Adds an 'X' if the previous command had a non-zero exit.
+
 ### `git`
+
+Displays the current git branch and whether the repository has been modified.
+
+Checking for modified files is potentially slow. Set `$AGNOSTER_PROMPT_TIMEOUT` to limit the maximum time to spend waiting for `git status`.
+
+Configuration variables: `$AGNOSTER_PROMPT_TIMEOUT`.
 
 ### `context`
 
+Include 'user@hostname'. The user will be ommitted if it matches `$DEFAULT_USER`. Hostname is only included for ssh connections.
+
+Configuration variables: `$DEFAULT_USER`.
+
 ### `virtualenv`
+
+Name of the current conda or virtualenv environment.
 
 Configuration variables: `$VIRTUAL_ENV_DISABLE_PROMPT`.
 
@@ -143,16 +158,29 @@ Just a blank space. Useful in conjunction with `newline` for formatting things.
 
 ### `k8s`
 
+Kubernetes context
+
+Configuration variables: `$KUBECONFIG`. Custom config file (default `~/.kube/config`)
+
 ### `aws`
+
+Amazon AWS profile
 
 ### `azure`
 
+Microsoft Azure cloud
+
 ### `gcp`
 
+Google cloud project
+
 ### `filesystem`
+
+Filesystem for the current directory (e.g. /dev/sda1)
 
 ### `random_emoji`
 
 Displays a random emoji character, selected from either a predefined list, or a wide range of the emoji Unicode range.
 
 Configuration variables: `$AGNOSTER_RANDOM_EMOJI`, `$AGNOSTER_RANDOM_EMOJI_EACH_PROMPT`, `$AGNOSTER_RANDOM_EMOJI_REALLY_RANDOM`.
+


### PR DESCRIPTION
This should limit one of the biggest reasons for slow prompts,
mitigating #6.

Set `$AGNOSTER_PROMPT_TIMEOUT` to limit the amount of time the git
command can run.

This requires GNU timeout, so it is disabled by default.

I tried to make this apply globally for all prompts. However,
GNU `timeout` only works for full processes, not for shell functions.
My attempt at a [zsh
implementation](https://gist.github.com/sbliven/0da4eba5380ba514accb4118d481fbc9)
failed due to job control limitations on non-interactive shells.